### PR TITLE
Adapting to pupet v0.53 export API namespace

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "typescript.tsdk": "./node_modules/typescript/lib",
 
-  "editor.fontFamily": "'Fira Code iScript', Consolas, 'Courier New', monospace",
+  "editor.fontFamily": "Consolas, 'Courier New', monospace",
   "editor.fontLigatures": true,
 
   "editor.tokenColorCustomizations": {

--- a/examples/ding-dong-bot.ts
+++ b/examples/ding-dong-bot.ts
@@ -1,13 +1,5 @@
-import {
-  EventErrorPayload,
-  EventLoginPayload,
-  EventLogoutPayload,
-  EventMessagePayload,
-  EventScanPayload,
-  MessageType,
-  ScanStatus,
-  FileBox,
-}                     from 'wechaty-puppet'
+import * as PUPPET  from 'wechaty-puppet'
+import { FileBox } from 'file-box'
 
 import { PuppetService } from '../src/mod.js'
 
@@ -54,7 +46,7 @@ puppet.start()
  *  `scan`, `login`, `logout`, `error`, and `message`
  *
  */
-function onScan (payload: EventScanPayload) {
+function onScan (payload: PUPPET.payload.EventScan) {
   if (payload.qrcode) {
     const qrcodeImageUrl = [
       'https://wechaty.js.org/qrcode/',
@@ -63,11 +55,11 @@ function onScan (payload: EventScanPayload) {
 
     console.info(`[${payload.status}] ${qrcodeImageUrl}\nScan QR Code above to log in: `)
   } else {
-    console.info(`[${payload.status}] `, ScanStatus[payload.status])
+    console.info(`[${payload.status}] `, PUPPET.type.ScanStatus[payload.status])
   }
 }
 
-async function onLogin (payload: EventLoginPayload) {
+async function onLogin (payload: PUPPET.payload.EventLogin) {
   console.info(`${payload.contactId} login`)
 
   const contactPayload = await puppet.contactPayload(payload.contactId)
@@ -76,11 +68,11 @@ async function onLogin (payload: EventLoginPayload) {
   puppet.messageSendText(payload.contactId, 'Wechaty login').catch(console.error)
 }
 
-function onLogout (payload: EventLogoutPayload) {
+function onLogout (payload: PUPPET.payload.EventLogout) {
   console.info(`${payload.contactId} logouted`)
 }
 
-function onError (payload: EventErrorPayload) {
+function onError (payload: PUPPET.payload.EventError) {
   console.error('Bot error:', payload.data)
   /*
   if (bot.logonoff()) {
@@ -95,7 +87,7 @@ function onError (payload: EventErrorPayload) {
  *    dealing with Messages.
  *
  */
-async function onMessage (payload: EventMessagePayload) {
+async function onMessage (payload: PUPPET.payload.EventMessage) {
   console.info(`onMessage(${payload.messageId})`)
 
   // const DEBUG: boolean = true
@@ -126,7 +118,7 @@ async function onMessage (payload: EventMessagePayload) {
     return
   }
 
-  if (messagePayload.type === MessageType.Text
+  if (messagePayload.type === PUPPET.type.Message.Text
       && /^ding$/i.test(messagePayload.text || '')
   ) {
     const conversationId = messagePayload.roomId || messagePayload.fromId

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet-service",
-  "version": "0.40.1",
+  "version": "0.41.0",
   "description": "Puppet Service for Wechaty",
   "type": "module",
   "exports": {
@@ -13,7 +13,7 @@
   "engines": {
     "node": ">=16",
     "npm": ">=7",
-    "wechaty": ">=0.77"
+    "wechaty": ">=0.79"
   },
   "scripts": {
     "build": "tsc && tsc -p tsconfig.cjs.json",
@@ -58,17 +58,11 @@
     "@types/semver": "^7.3.9",
     "@types/uuid": "^8.3.1",
     "@types/ws": "^8.2.0",
-    "cross-env": "^7.0.3",
-    "npm-run-all": "^4.1.5",
-    "pkg-jq": "^0.2.11",
-    "shx": "^0.3.3",
-    "tstest": "^0.5.16",
-    "typescript": "^4.4.4",
-    "wechaty": "^0.75.25",
-    "wechaty-puppet-mock": "^0.35.1"
+    "wechaty": "^0.79",
+    "wechaty-puppet-mock": "^0.37"
   },
   "peerDependencies": {
-    "wechaty-puppet": ">=0.52"
+    "wechaty-puppet": ">=0.53.8"
   },
   "dependencies": {
     "clone-class": "^1.0.2",

--- a/src/client/payload-store.ts
+++ b/src/client/payload-store.ts
@@ -4,18 +4,15 @@ import fs from 'fs'
 
 import semverPkg from 'semver'
 
-import {
-  log,
-  // MessagePayload,
-  ContactPayload,
-  RoomPayload,
-  RoomMemberPayload,
-}                     from 'wechaty-puppet'
+import type * as PUPPET from 'wechaty-puppet'
 
 import { FlashStore } from 'flash-store'
 // import LRU            from 'lru-cache'
 
-import { VERSION } from '../config.js'
+import {
+  VERSION,
+  log,
+}             from '../config.js'
 
 const { major, minor } = semverPkg
 
@@ -27,9 +24,9 @@ class PayloadStore {
 
   // public message?    : LRU<string, MessagePayload>
 
-  public contact?    : FlashStore<string, ContactPayload>
-  public roomMember? : FlashStore<string, RoomMemberPayload>
-  public room?       : FlashStore<string, RoomPayload>
+  public contact?    : FlashStore<string, PUPPET.payload.Contact>
+  public roomMember? : FlashStore<string, PUPPET.payload.RoomMember>
+  public room?       : FlashStore<string, PUPPET.payload.Room>
 
   protected storeDir:   string
   protected accountId?: string

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,7 @@
 /// <reference path="./typings.d.ts" />
 
+import { log } from 'wechaty-puppet'
+
 import { packageJson } from './package-json.js'
 
 import * as rootEnvVars from './env-vars.js'
@@ -23,6 +25,7 @@ const GRPC_OPTIONS = {
 
 export {
   envVars,
+  log,
   GRPC_OPTIONS,
   VERSION,
 }

--- a/src/deprecated/chunk-pb.spec.ts
+++ b/src/deprecated/chunk-pb.spec.ts
@@ -4,7 +4,7 @@ import { test } from 'tstest'
 
 import { PassThrough } from 'stream'
 
-import { FileBox } from 'wechaty-puppet'
+import { FileBox } from 'file-box'
 
 import {
   puppet,

--- a/src/deprecated/conversation-id-file-box.spec.ts
+++ b/src/deprecated/conversation-id-file-box.spec.ts
@@ -25,7 +25,7 @@ import {
 
 import { test }         from 'tstest'
 import { PassThrough }  from 'stream'
-import { FileBox }      from 'wechaty-puppet'
+import { FileBox }      from 'file-box'
 
 import { nextData }     from './next-data.js'
 import {

--- a/src/deprecated/conversation-id-file-box.ts
+++ b/src/deprecated/conversation-id-file-box.ts
@@ -1,4 +1,4 @@
-import type { FileBox }              from 'wechaty-puppet'
+import type { FileBox }              from 'file-box'
 import { PassThrough }          from 'stream'
 import type { Readable }             from 'stronger-typed-streams'
 

--- a/src/deprecated/file-box-chunk.spec.ts
+++ b/src/deprecated/file-box-chunk.spec.ts
@@ -23,7 +23,7 @@ import { test } from 'tstest'
 
 import { PassThrough }  from 'stream'
 import type { Duplex }       from 'stronger-typed-streams'
-import { FileBox }      from 'wechaty-puppet'
+import { FileBox }      from 'file-box'
 
 import {
   puppet,

--- a/src/deprecated/file-box-chunk.ts
+++ b/src/deprecated/file-box-chunk.ts
@@ -1,4 +1,4 @@
-import { FileBox }      from 'wechaty-puppet'
+import { FileBox }      from 'file-box'
 import { PassThrough }  from 'stream'
 import {
   Readable,

--- a/src/deprecated/file-box-pb.spec.ts
+++ b/src/deprecated/file-box-pb.spec.ts
@@ -2,7 +2,7 @@
 
 import { test } from 'tstest'
 
-import { FileBox } from 'wechaty-puppet'
+import { FileBox } from 'file-box'
 
 import {
   puppet,

--- a/src/deprecated/file-box-pb.ts
+++ b/src/deprecated/file-box-pb.ts
@@ -1,4 +1,4 @@
-import type { FileBox }      from 'wechaty-puppet'
+import type { FileBoxInterface }      from 'file-box'
 import type { Readable }     from 'stronger-typed-streams'
 
 import {
@@ -17,7 +17,7 @@ import type { FileBoxPb }        from './file-box-pb.type.js'
 function packFileBoxToPb<T extends FileBoxPb> (
   PbConstructor: { new(): T },
 ) {
-  return async (fileBox: FileBox) => {
+  return async (fileBox: FileBoxInterface) => {
     const fileBoxChunkStream = await packFileBoxToChunk(fileBox)
     const pbFileBox = packFileBoxChunkToPb(PbConstructor)(fileBoxChunkStream)
     return pbFileBox
@@ -29,7 +29,7 @@ function packFileBoxToPb<T extends FileBoxPb> (
  */
 async function unpackFileBoxFromPb<T extends FileBoxPb> (
   pbStream: Readable<T>,
-): Promise<FileBox> {
+): Promise<FileBoxInterface> {
   const fileBoxChunkStream = unpackFileBoxChunkFromPb(pbStream)
   const fileBox = await unpackFileBoxFromChunk(fileBoxChunkStream)
   return fileBox

--- a/src/deprecated/serialize-file-box.ts
+++ b/src/deprecated/serialize-file-box.ts
@@ -1,10 +1,15 @@
-import { FileBox } from 'wechaty-puppet'
-import { FileBoxType } from 'file-box'
+import {
+  FileBox,
+  FileBoxType,
+}                     from 'file-box'
+import type {
+  FileBoxInterface,
+}                     from 'file-box'
 
 /**
  * @deprecated Will be removed after Dec 31, 2022
  */
-export const serializeFileBox = async (fileBox: FileBox): Promise<string> => {
+export const serializeFileBox = async (fileBox: FileBoxInterface): Promise<string> => {
   const serializableFileBoxTypes = [
     FileBoxType.Base64,
     FileBoxType.Url,

--- a/src/server/event-stream-manager.ts
+++ b/src/server/event-stream-manager.ts
@@ -3,27 +3,9 @@ import {
   grpc,
 }                                   from 'wechaty-grpc'
 
-import {
-  EventDirtyPayload,
-  EventDongPayload,
-  EventErrorPayload,
-  EventFriendshipPayload,
-  EventHeartbeatPayload,
-  EventLoginPayload,
-  EventLogoutPayload,
-  EventMessagePayload,
-  EventReadyPayload,
-  EventRoomInvitePayload,
-  EventRoomJoinPayload,
-  EventRoomLeavePayload,
-  EventRoomTopicPayload,
-  EventScanPayload,
-  PUPPET_EVENT_DICT,
-  PuppetEventName,
-  log,
-  PuppetInterface,
-}                                   from 'wechaty-puppet'
+import * as PUPPET from 'wechaty-puppet'
 
+import { log } from '../config.js'
 import {
   EventTypeRev,
 }                     from '../event-type-rev.js'
@@ -35,7 +17,7 @@ class EventStreamManager {
   private puppetListening = false
 
   constructor (
-    public puppet: PuppetInterface,
+    public puppet: PUPPET.impl.Puppet,
   ) {
     log.verbose('EventStreamManager', 'constructor(%s)', puppet)
   }
@@ -71,7 +53,7 @@ class EventStreamManager {
      */
     const connectSuccessHeartbeatPayload = {
       data: 'Wechaty Puppet gRPC stream connect successfully',
-    } as EventHeartbeatPayload
+    } as PUPPET.payload.EventHeartbeat
     this.grpcEmit(
       grpcPuppet.EventType.EVENT_TYPE_HEARTBEAT,
       connectSuccessHeartbeatPayload,
@@ -85,7 +67,7 @@ class EventStreamManager {
 
       const payload = {
         contactId: this.puppet.currentUserId,
-      } as EventLoginPayload
+      } as PUPPET.payload.EventLogin
 
       this.grpcEmit(grpcPuppet.EventType.EVENT_TYPE_LOGIN, payload)
     }
@@ -145,7 +127,7 @@ class EventStreamManager {
       this.puppetListening = false
     }
 
-    const eventNameList: PuppetEventName[] = Object.keys(PUPPET_EVENT_DICT) as PuppetEventName[]
+    const eventNameList: PUPPET.type.PuppetEventName[] = Object.keys(PUPPET.type.PUPPET_EVENT_DICT) as PUPPET.type.PuppetEventName[]
     for (const eventName of eventNameList) {
       log.verbose('EventStreamManager',
         'connectPuppetEventToStreamingCall() this.puppet.on(%s) (listenerCount:%s) registering...',
@@ -155,98 +137,98 @@ class EventStreamManager {
 
       switch (eventName) {
         case 'dong': {
-          const listener = (payload: EventDongPayload) => this.grpcEmit(grpcPuppet.EventType.EVENT_TYPE_DONG, payload)
+          const listener = (payload: PUPPET.payload.EventDong) => this.grpcEmit(grpcPuppet.EventType.EVENT_TYPE_DONG, payload)
           this.puppet.on('dong', listener)
           const off = () => this.puppet.off('dong', listener)
           offCallbackList.push(off)
           break
         }
         case 'dirty': {
-          const listener = (payload: EventDirtyPayload) => this.grpcEmit(grpcPuppet.EventType.EVENT_TYPE_DIRTY, payload)
+          const listener = (payload: PUPPET.payload.EventDirty) => this.grpcEmit(grpcPuppet.EventType.EVENT_TYPE_DIRTY, payload)
           this.puppet.on('dirty', listener)
           const off = () => this.puppet.off('dirty', listener)
           offCallbackList.push(off)
           break
         }
         case 'error': {
-          const listener = (payload: EventErrorPayload) => this.grpcEmit(grpcPuppet.EventType.EVENT_TYPE_ERROR, payload)
+          const listener = (payload: PUPPET.payload.EventError) => this.grpcEmit(grpcPuppet.EventType.EVENT_TYPE_ERROR, payload)
           this.puppet.on('error', listener)
           const off = () => this.puppet.off('error', listener)
           offCallbackList.push(off)
           break
         }
         case 'heartbeat': {
-          const listener = (payload: EventHeartbeatPayload) => this.grpcEmit(grpcPuppet.EventType.EVENT_TYPE_HEARTBEAT, payload)
+          const listener = (payload: PUPPET.payload.EventHeartbeat) => this.grpcEmit(grpcPuppet.EventType.EVENT_TYPE_HEARTBEAT, payload)
           this.puppet.on('heartbeat', listener)
           const off = () => this.puppet.off('heartbeat', listener)
           offCallbackList.push(off)
           break
         }
         case 'friendship': {
-          const listener = (payload: EventFriendshipPayload) => this.grpcEmit(grpcPuppet.EventType.EVENT_TYPE_FRIENDSHIP, payload)
+          const listener = (payload: PUPPET.payload.EventFriendship) => this.grpcEmit(grpcPuppet.EventType.EVENT_TYPE_FRIENDSHIP, payload)
           this.puppet.on('friendship', listener)
           const off = () => this.puppet.off('friendship', listener)
           offCallbackList.push(off)
           break
         }
         case 'login': {
-          const listener = (payload: EventLoginPayload) => this.grpcEmit(grpcPuppet.EventType.EVENT_TYPE_LOGIN, payload)
+          const listener = (payload: PUPPET.payload.EventLogin) => this.grpcEmit(grpcPuppet.EventType.EVENT_TYPE_LOGIN, payload)
           this.puppet.on('login', listener)
           const off = () => this.puppet.off('login', listener)
           offCallbackList.push(off)
           break
         }
         case 'logout': {
-          const listener = (payload: EventLogoutPayload) => this.grpcEmit(grpcPuppet.EventType.EVENT_TYPE_LOGOUT, payload)
+          const listener = (payload: PUPPET.payload.EventLogout) => this.grpcEmit(grpcPuppet.EventType.EVENT_TYPE_LOGOUT, payload)
           this.puppet.on('logout', listener)
           const off = () => this.puppet.off('logout', listener)
           offCallbackList.push(off)
           break
         }
         case 'message': {
-          const listener = (payload: EventMessagePayload) => this.grpcEmit(grpcPuppet.EventType.EVENT_TYPE_MESSAGE, payload)
+          const listener = (payload: PUPPET.payload.EventMessage) => this.grpcEmit(grpcPuppet.EventType.EVENT_TYPE_MESSAGE, payload)
           this.puppet.on('message', listener)
           const off = () => this.puppet.off('message', listener)
           offCallbackList.push(off)
           break
         }
         case 'ready': {
-          const listener = (payload: EventReadyPayload) => this.grpcEmit(grpcPuppet.EventType.EVENT_TYPE_READY, payload)
+          const listener = (payload: PUPPET.payload.EventReady) => this.grpcEmit(grpcPuppet.EventType.EVENT_TYPE_READY, payload)
           this.puppet.on('ready', listener)
           const off = () => this.puppet.off('ready', listener)
           offCallbackList.push(off)
           break
         }
         case 'room-invite': {
-          const listener = (payload: EventRoomInvitePayload) => this.grpcEmit(grpcPuppet.EventType.EVENT_TYPE_ROOM_INVITE, payload)
+          const listener = (payload: PUPPET.payload.EventRoomInvite) => this.grpcEmit(grpcPuppet.EventType.EVENT_TYPE_ROOM_INVITE, payload)
           this.puppet.on('room-invite', listener)
           const off = () => this.puppet.off('room-invite', listener)
           offCallbackList.push(off)
           break
         }
         case 'room-join': {
-          const listener = (payload: EventRoomJoinPayload) => this.grpcEmit(grpcPuppet.EventType.EVENT_TYPE_ROOM_JOIN, payload)
+          const listener = (payload: PUPPET.payload.EventRoomJoin) => this.grpcEmit(grpcPuppet.EventType.EVENT_TYPE_ROOM_JOIN, payload)
           this.puppet.on('room-join', listener)
           const off = () => this.puppet.off('room-join', listener)
           offCallbackList.push(off)
           break
         }
         case 'room-leave': {
-          const listener = (payload: EventRoomLeavePayload) => this.grpcEmit(grpcPuppet.EventType.EVENT_TYPE_ROOM_LEAVE, payload)
+          const listener = (payload: PUPPET.payload.EventRoomLeave) => this.grpcEmit(grpcPuppet.EventType.EVENT_TYPE_ROOM_LEAVE, payload)
           this.puppet.on('room-leave', listener)
           const off = () => this.puppet.off('room-leave', listener)
           offCallbackList.push(off)
           break
         }
         case 'room-topic': {
-          const listener = (payload: EventRoomTopicPayload) => this.grpcEmit(grpcPuppet.EventType.EVENT_TYPE_ROOM_TOPIC, payload)
+          const listener = (payload: PUPPET.payload.EventRoomTopic) => this.grpcEmit(grpcPuppet.EventType.EVENT_TYPE_ROOM_TOPIC, payload)
           this.puppet.on('room-topic', listener)
           const off = () => this.puppet.off('room-topic', listener)
           offCallbackList.push(off)
           break
         }
         case 'scan': {
-          const listener = (payload: EventScanPayload) => this.grpcEmit(grpcPuppet.EventType.EVENT_TYPE_SCAN, payload)
+          const listener = (payload: PUPPET.payload.EventScan) => this.grpcEmit(grpcPuppet.EventType.EVENT_TYPE_SCAN, payload)
           this.puppet.on('scan', listener)
           const off = () => this.puppet.off('scan', listener)
           offCallbackList.push(off)

--- a/tests/performance.spec.ts
+++ b/tests/performance.spec.ts
@@ -13,13 +13,7 @@ import {
   sinon,
 }             from 'tstest'
 
-import {
-  PuppetOptions,
-  ContactPayload,
-  log,
-  ContactGender,
-  ContactType,
-}                               from 'wechaty-puppet'
+import * as PUPPET from 'wechaty-puppet'
 
 import {
   PuppetMock,
@@ -31,6 +25,8 @@ import {
   PuppetServerOptions,
 }                               from '../src/mod.js'
 
+import { log } from '../src/config.js'
+
 const idToName = (id: string) => {
   return `name of ${id}`
 }
@@ -41,15 +37,15 @@ class PuppetTest extends PuppetMock {
     super(...args)
   }
 
-  override async contactRawPayload (id: string): Promise<ContactPayload> {
+  override async contactRawPayload (id: string): Promise<PUPPET.payload.Contact> {
     log.verbose('PuppetTest', 'contactRawPayload(%s)', id)
-    const rawPayload: ContactPayload = {
+    const rawPayload: PUPPET.payload.Contact = {
       avatar : '',
-      gender : ContactGender.Male,
+      gender : PUPPET.type.ContactGender.Male,
       id,
       name : idToName(id),
       phone: [],
-      type   : ContactType.Individual,
+      type   : PUPPET.type.Contact.Individual,
     }
 
     await new Promise<void>(resolve => {
@@ -94,7 +90,7 @@ test.skip('stress testing', async t => {
   const puppetOptions = {
     endpoint : ENDPOINT,
     token    : TOKEN,
-  } as PuppetOptions
+  } as PUPPET.PuppetOptions
 
   const puppetService = new PuppetService(puppetOptions)
   await puppetService.start()


### PR DESCRIPTION
```ts
import * as PUPPET from 'wechaty-puppet'
```

- PUPPET.Puppet
- PUPPET.payload.*
- PUPPET.type.*
- etc.