### PR TITLE
Reproduce: `tryShutdown` freeze app

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet-service",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "description": "Puppet Service for Wechaty",
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet-service",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "description": "Puppet Service for Wechaty",
   "type": "module",
   "exports": {

--- a/src/client/puppet-service.ts
+++ b/src/client/puppet-service.ts
@@ -321,7 +321,7 @@ export class PuppetService extends PUPPET.Puppet {
   override async logout (reason?: string): Promise<void> {
     log.verbose('PuppetService', 'logout(%s)', reason ? `"${reason}"` : '')
 
-    super.logout(reason)
+    await super.logout(reason)
 
     try {
       await util.promisify(

--- a/src/server/event-stream-manager.ts
+++ b/src/server/event-stream-manager.ts
@@ -62,7 +62,7 @@ class EventStreamManager {
     /**
       * We emit the login event if current the puppet is logged in.
       */
-    if (this.puppet.logonoff()) {
+    if (this.puppet.isLoggedIn) {
       log.verbose('EventStreamManager', 'start() puppet is logged in, emit a login event for downstream')
 
       const payload = {

--- a/src/server/puppet-server.ts
+++ b/src/server/puppet-server.ts
@@ -181,10 +181,10 @@ export class PuppetServer {
       this.grpcServer = undefined
 
       log.verbose('PuppetServer', 'stop() shuting down gRPC server ...')
-      // const future = await util.promisify(
-      //   grpcServer.tryShutdown
-      //     .bind(grpcServer),
-      // )()
+      const future = await util.promisify(
+        grpcServer.tryShutdown
+          .bind(grpcServer),
+      )()
 
       try {
         await new Promise(resolve => setImmediate(resolve))
@@ -196,7 +196,7 @@ export class PuppetServer {
          * FIXME: even after called `forceShutdown()`, the `tryShutdown()` can not resolved.
          *  commented out the `await` for now to make it work temporary.
          */
-        // await future
+        await future
 
       } catch (e) {
         log.warn('PuppetServer', 'stop() gRPC shutdown rejection: %s', (e as Error).message)


### PR DESCRIPTION
TO: @murgatroid99

Here's how to reproduce the issue

- https://github.com/grpc/grpc-node/issues/1458

## Reproduce steps

Branch: https://github.com/wechaty/puppet-service/tree/try-shutdown

```sh
git clone git@github.com:wechaty/puppet-service.git
cd puppet-service
git checkout try-shutdown
npm install // Node.js v16+ and NPM v7+ required

// The below test will block forever
./tests/grpc-stream.spec.ts 
```

## Related Code

Please see the commit:

- https://github.com/wechaty/puppet-service/pull/185/commits/517b7816a3e6b297f2fa84aec826dc0f1f6f13ae

If we comment out those lines, then the test will be able to finish.

Related to:

- #176